### PR TITLE
Add CI workflow to verify site build

### DIFF
--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -1,0 +1,34 @@
+name: Verify Site Build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build site
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          pip install uv
+          uv sync --frozen
+
+      - name: Build site
+        run: uv run mkdocs build


### PR DESCRIPTION
Added `.github/workflows/test-ci.yml` to run `mkdocs build` on PRs and pushes to `main`.

---
*PR created automatically by Jules for task [13279996217923122623](https://jules.google.com/task/13279996217923122623) started by @juanfe2793*