### PR TITLE
chore: suppress MkDocs 2.0 incompatibility warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,8 @@ jobs:
           uv sync --frozen
         
       - name: Build site
+        env:
+          NO_MKDOCS_2_WARNING: 1
         run: uv run mkdocs build
         
       - name: Setup Pages

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -31,4 +31,6 @@ jobs:
           uv sync --frozen
 
       - name: Build site
+        env:
+          NO_MKDOCS_2_WARNING: 1
         run: uv run mkdocs build

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@ FROM python:3.11-slim
 # Set the working directory in the container
 WORKDIR /app
 
+# Suppress MkDocs 2.0 warning
+ENV NO_MKDOCS_2_WARNING=1
+
 # Install uv
 RUN pip install uv
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This guide explains how to build and preview the portfolio locally before pushin
     ```
 3.  **Run Development Server:**
     ```bash
-    uv run mkdocs serve
+    NO_MKDOCS_2_WARNING=1 uv run mkdocs serve
     ```
     Access at [http://localhost:8000](http://localhost:8000).
 


### PR DESCRIPTION
This PR adds the `NO_MKDOCS_2_WARNING=1` environment variable to suppress the warning about MkDocs 2.0 incompatibility with Material for MkDocs.

Changes include:
- `Dockerfile`: Added `ENV NO_MKDOCS_2_WARNING=1`.
- `.github/workflows/ci.yml` and `.github/workflows/test-ci.yml`: Added `env: NO_MKDOCS_2_WARNING: 1` to the `Build site` step.
- `README.md`: Updated the local development command to include `NO_MKDOCS_2_WARNING=1` when running `uv run mkdocs serve`.

---
*PR created automatically by Jules for task [11051195305563750857](https://jules.google.com/task/11051195305563750857) started by @juanfe2793*