### PR TITLE
feat: implement interactive project preview cards on homepage

### DIFF
--- a/src/components/FeaturedProjects/index.tsx
+++ b/src/components/FeaturedProjects/index.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import clsx from 'clsx';
+import ProjectCard from '@site/src/components/ProjectCard';
+import { projects } from '@site/src/data/projects';
+import Heading from '@theme/Heading';
+import styles from './styles.module.css';
+
+export default function FeaturedProjects() {
+  return (
+    <section className={clsx(styles.featuredProjects, 'container')}>
+      <div className={styles.eyebrow}>FEATURED PROJECTS</div>
+      <Heading as="h2" className={styles.sectionTitle}>
+        Architecture & Infrastructure
+      </Heading>
+      <div className={styles.grid}>
+        {projects.map((project, idx) => (
+          <div key={idx} className={styles.gridItem}>
+            <ProjectCard project={project} />
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/FeaturedProjects/styles.module.css
+++ b/src/components/FeaturedProjects/styles.module.css
@@ -1,0 +1,49 @@
+.featuredProjects {
+  padding-top: 4rem;
+  padding-bottom: 4rem;
+}
+
+.eyebrow {
+  font-size: 0.85rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  color: var(--ifm-color-emphasis-600);
+  margin-bottom: 0.5rem;
+  font-family: var(--ifm-font-family-monospace);
+  text-transform: uppercase;
+}
+
+.sectionTitle {
+  font-size: 2rem;
+  margin-bottom: 2.5rem;
+  color: var(--ifm-heading-color);
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1.5rem;
+}
+
+/* Tablet: 2 columns, last item spans full width if odd number of items */
+@media (min-width: 768px) {
+  .grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  /* If there are exactly 3 items, make the last one span both columns */
+  .gridItem:nth-child(3):last-child {
+    grid-column: 1 / -1;
+  }
+}
+
+/* Desktop: 3 columns */
+@media (min-width: 996px) {
+  .grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+
+  .gridItem:nth-child(3):last-child {
+    grid-column: auto;
+  }
+}

--- a/src/components/ProjectCard/index.tsx
+++ b/src/components/ProjectCard/index.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import Link from '@docusaurus/Link';
+import SkillBadge from '@site/src/components/SkillBadge';
+import type { Project } from '@site/src/data/projects';
+import styles from './styles.module.css';
+
+export default function ProjectCard({ project }: { project: Project }) {
+  return (
+    <div className={styles.card}>
+      <div className={styles.imagePlaceholder}>
+        <svg
+          width="100%"
+          height="160"
+          xmlns="http://www.w3.org/2000/svg"
+          preserveAspectRatio="xMidYMid slice"
+          focusable="false"
+          role="img"
+          aria-label="Architecture Placeholder"
+        >
+          <rect width="100%" height="100%" fill="var(--ifm-color-emphasis-200)" />
+          <text
+            x="50%"
+            y="50%"
+            fill="var(--ifm-color-emphasis-600)"
+            dy=".3em"
+            textAnchor="middle"
+            fontFamily="monospace"
+          >
+            Architecture Diagram
+          </text>
+        </svg>
+      </div>
+
+      <div className={styles.cardContent}>
+        <h3 className={styles.title}>{project.title}</h3>
+        <p className={styles.summary}>{project.summary}</p>
+
+        <div className={styles.metrics}>
+          {project.metrics.map((metric, idx) => (
+            <div key={idx} className={styles.metricItem}>
+              <span className={styles.metricIcon}>⚡</span>
+              <span className={styles.metricText}>{metric}</span>
+            </div>
+          ))}
+        </div>
+
+        <div className={styles.tags}>
+          {project.tags.map(tag => (
+            <SkillBadge key={tag} name={tag} variant="tag" />
+          ))}
+        </div>
+
+        <div className={styles.footer}>
+          <Link to={project.link} className={styles.readMore}>
+            Read Case Study <span className={styles.arrow}>→</span>
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ProjectCard/styles.module.css
+++ b/src/components/ProjectCard/styles.module.css
@@ -1,0 +1,112 @@
+.card {
+  display: flex;
+  flex-direction: column;
+  background-color: var(--ifm-card-background-color);
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: var(--ifm-global-radius);
+  overflow: hidden;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  height: 100%;
+}
+
+.card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.1);
+  border-color: var(--ifm-color-primary);
+}
+
+[data-theme='dark'] .card:hover {
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.4);
+}
+
+.imagePlaceholder {
+  width: 100%;
+  height: 160px;
+  background-color: var(--ifm-color-emphasis-100);
+  border-bottom: 1px solid var(--ifm-color-emphasis-200);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.cardContent {
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+}
+
+.title {
+  font-size: 1.25rem;
+  margin-bottom: 0.5rem;
+  color: var(--ifm-heading-color);
+  font-weight: 700;
+}
+
+.summary {
+  font-size: 0.9rem;
+  color: var(--ifm-color-emphasis-700);
+  margin-bottom: 1rem;
+  line-height: 1.5;
+}
+
+.metrics {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 1.25rem;
+  padding: 0.75rem;
+  background-color: var(--ifm-color-emphasis-100);
+  border-radius: 4px;
+}
+
+.metricItem {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+  font-family: var(--ifm-font-family-monospace);
+  color: var(--ifm-color-emphasis-800);
+}
+
+.metricIcon {
+  color: var(--ifm-color-primary);
+}
+
+.tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 1.5rem;
+  margin-top: auto;
+}
+
+.footer {
+  margin-top: auto;
+  padding-top: 1rem;
+  border-top: 1px solid var(--ifm-color-emphasis-200);
+}
+
+.readMore {
+  display: inline-flex;
+  align-items: center;
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: var(--ifm-color-primary);
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.readMore:hover {
+  color: var(--ifm-color-primary-dark);
+  text-decoration: none;
+}
+
+.arrow {
+  margin-left: 0.25rem;
+  transition: transform 0.2s ease;
+}
+
+.readMore:hover .arrow {
+  transform: translateX(4px);
+}

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -1,0 +1,35 @@
+export type Project = {
+  title: string;
+  summary: string;
+  description: string;
+  metrics: string[];
+  tags: string[];
+  link: string;
+};
+
+export const projects: Project[] = [
+  {
+    title: 'Cloud Native API Gateway',
+    summary: 'Architected and implemented a Domain Gateway Infrastructure using Kong.',
+    description: 'Developed Terraform modules for standardized deployment, configuration management and internal custom plugins testing and delivery. Enabled cross-domain connectivity with TLS/gRPC support.',
+    metrics: ['3M+ RPS Processed', '99.999% Availability', 'Cross-domain TLS/gRPC'],
+    tags: ['Kong', 'Terraform', 'API Gateway'],
+    link: '/docs/case-studies/api-gateway',
+  },
+  {
+    title: 'Twilio-wide DNS Modernization',
+    summary: 'Architected and implemented a centralized DNS boundary for the One Twilio Kubernetes platform.',
+    description: 'This agnostic architecture supports multi-cluster/multi-region deployments and simplifies service discovery.',
+    metrics: ['100+ Hosted Zones', '80% Less Ops Burnout', 'Multi-Region Support'],
+    tags: ['DNS', 'Kubernetes', 'Multi-Region'],
+    link: '/docs/case-studies/dns-modernization',
+  },
+  {
+    title: 'Automated Observability & Load Testing',
+    summary: 'Standardized platform observability with OpenTelemetry and k6.',
+    description: 'Enabling data-driven performance optimizations across all Twilio Kubernetes platform services.',
+    metrics: ['OpenTelemetry Standardized', 'k6 Load Testing', 'Data-driven Optimizations'],
+    tags: ['OpenTelemetry', 'k6', 'Helm'],
+    link: '/docs/case-studies/observability-load-testing',
+  },
+];

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -147,71 +147,6 @@
   margin: 0;
 }
 
-/* Projects Section */
-.projects {
-  padding: 6rem 0;
-}
-
-.projectsList {
-  display: grid;
-  grid-template-columns: repeat(12, 1fr);
-  gap: 0;
-}
-
-.projectRow {
-  grid-column: 3 / 11;
-  display: grid;
-  grid-template-columns: 60px 1fr;
-  gap: 2rem;
-  padding: 2rem 0;
-  border-bottom: 1px solid var(--rule);
-  align-items: start;
-}
-
-.projectIndex {
-  font-family: var(--ifm-font-family-monospace);
-  font-size: 1rem;
-  color: var(--ink-soft);
-}
-
-.projectTitle {
-  font-size: 1.5rem;
-  margin: 0 0 0.5rem 0;
-}
-
-.projectDesc {
-  font-size: 1.1rem;
-  margin: 0 0 1.5rem 0;
-  max-width: 60ch;
-}
-
-.projectFooter {
-  display: flex;
-  align-items: center;
-  gap: 1.5rem;
-  flex-wrap: wrap;
-}
-
-.projectTags {
-  display: flex;
-  gap: 0.5rem;
-  flex-wrap: wrap;
-}
-
-.projectLink {
-  font-family: var(--ifm-font-family-monospace);
-  font-size: 0.85rem;
-  color: var(--accent);
-  text-decoration: none;
-  white-space: nowrap;
-  transition: opacity 0.2s;
-}
-
-.projectLink:hover {
-  opacity: 0.7;
-  color: var(--accent);
-}
-
 /* CTA / Colophon */
 .cta {
   padding: 6rem 0;
@@ -275,13 +210,5 @@
     border-top: 3px solid var(--accent);
     padding-left: 0;
     padding-top: 1.5rem;
-  }
-  .projectRow {
-    grid-column: 1 / -1;
-    grid-template-columns: 1fr;
-    gap: 0.5rem;
-  }
-  .projectIndex {
-    font-size: 0.8rem;
   }
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -9,39 +9,9 @@ import SkillBadge from '@site/src/components/SkillBadge';
 import ImpactMatrix from '@site/src/components/ImpactMatrix';
 import AIVision from '@site/src/components/AIVision';
 import SocialLinks from '@site/src/components/SocialLinks';
+import FeaturedProjects from '@site/src/components/FeaturedProjects';
 
 import styles from './index.module.css';
-
-type ProjectItem = {
-  title: string;
-  description: string;
-  tags: string[];
-  link: string;
-};
-
-const ProjectList: ProjectItem[] = [
-  {
-    title: 'Cloud Native API Gateway',
-    description:
-      'Architected and implemented a Domain Gateway Infrastructure using Kong. Developed Terraform modules for standardized deployment, configuration management and internal custom plugins testing and delivery. Enabled cross-domain connectivity with TLS/gRPC support.',
-    tags: ['3M+ RPS', '99.999% Availability', 'Kong', 'Terraform'],
-    link: '/docs/case-studies/api-gateway',
-  },
-  {
-    title: 'Twilio-wide DNS Modernization',
-    description:
-      'Architected and implemented a centralized DNS boundary for the One Twilio Kubernetes platform. This agnostic architecture supports multi-cluster/multi-region deployments and simplifies service discovery.',
-    tags: ['100+ Hosted Zones', '80% Less Ops Burnout', 'Multi-Region'],
-    link: '/docs/case-studies/dns-modernization',
-  },
-  {
-    title: 'Automated Observability & Load Testing',
-    description:
-      'Standardized platform observability with OpenTelemetry and k6, enabling data-driven performance optimizations across all Twilio Kubernetes platform services.',
-    tags: ['OpenTelemetry', 'k6', 'Helm'],
-    link: '/docs/case-studies/observability-load-testing',
-  },
-];
 
 function HeroSection() {
   const avatarSrc = useBaseUrl('/img/avatar.jpg');
@@ -115,35 +85,6 @@ function AboutSection() {
   );
 }
 
-function ProjectsSection() {
-  return (
-    <section className={clsx(styles.projects, 'container')}>
-      <div className={styles.projectsList}>
-        <div className={styles.eyebrow}>SELECTED WORK</div>
-        {ProjectList.map((project, idx) => (
-          <div key={idx} className={styles.projectRow}>
-            <div className={styles.projectIndex}>0{idx + 1}</div>
-            <div className={styles.projectMain}>
-              <Heading as="h3" className={styles.projectTitle}>{project.title}</Heading>
-              <p className={styles.projectDesc}>{project.description}</p>
-              <div className={styles.projectFooter}>
-                <div className={styles.projectTags}>
-                  {project.tags.map(tag => (
-                    <SkillBadge key={tag} name={tag} variant="tag" />
-                  ))}
-                </div>
-                <Link className={styles.projectLink} to={project.link}>
-                  Deep Dive →
-                </Link>
-              </div>
-            </div>
-          </div>
-        ))}
-      </div>
-    </section>
-  );
-}
-
 function CtaSection() {
   return (
     <section className={clsx(styles.cta, 'container')}>
@@ -172,8 +113,8 @@ export default function Home(): ReactNode {
         <div className="container"><ImpactMatrix /></div>
         <AboutSection />
         <div className="container"><AIVision /></div>
+        <FeaturedProjects />
         <HomepageFeatures />
-        <ProjectsSection />
         <CtaSection />
       </main>
     </Layout>


### PR DESCRIPTION
Fixes #30. This PR implements the `FeaturedProjects` section on the homepage containing interactive preview cards for the three flagship projects.

Changes:
- **Data Configuration:** Moved hardcoded project data from `src/pages/index.tsx` into a dedicated configuration file `src/data/projects.ts`.
- **ProjectCard Component:** Created a reusable UI component that displays an architecture placeholder, project title, summary, extracted impact metrics, skill tags, and a call-to-action link. The cards feature a subtle hover elevation and shadow transition, supporting both light and dark themes via standard Infima variables.
- **FeaturedProjects Component:** A new responsive grid container that mounts the `ProjectCard`s, transitioning from a single column on mobile, to a mixed 2-column on tablet, and a 3-column layout on desktop.
- **Homepage Integration:** Integrated the new section directly below the `AIVision` component on the homepage and cleaned up legacy hardcoded UI components and styles.

---
*PR created automatically by Jules for task [10547137486634187217](https://jules.google.com/task/10547137486634187217) started by @juanfe2793*