### PR TITLE
Fix: Render final values in ImpactMatrix instead of 0 on SSR

### DIFF
--- a/serve.log
+++ b/serve.log
@@ -1,0 +1,5 @@
+
+> portfolio@0.0.0 serve
+> docusaurus serve
+
+[SUCCESS] Serving "build" directory at: http://localhost:3000/Portfolio/

--- a/src/components/ImpactMatrix.tsx
+++ b/src/components/ImpactMatrix.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import CountUp from 'react-countup';
 import { useInView } from 'react-intersection-observer';
+import useIsBrowser from '@docusaurus/useIsBrowser';
 import styles from './ImpactMatrix.module.css';
 
 type MetricItem = {
@@ -47,6 +48,7 @@ const metrics: MetricItem[] = [
 ];
 
 export default function ImpactMatrix() {
+  const isBrowser = useIsBrowser();
   const { ref, inView } = useInView({
     triggerOnce: true,
     threshold: 0.1,
@@ -59,7 +61,7 @@ export default function ImpactMatrix() {
           <div key={idx} className={styles.glassPanel}>
             <span className={styles.label}>{metric.label}</span>
             <div className={styles.value}>
-              {inView ? (
+              {isBrowser && inView ? (
                 <CountUp
                   start={0}
                   end={metric.value}
@@ -70,7 +72,7 @@ export default function ImpactMatrix() {
                   separator=","
                 />
               ) : (
-                `${metric.prefix || ''}0${metric.suffix || ''}`
+                `${metric.prefix || ''}${metric.value}${metric.suffix || ''}`
               )}
             </div>
             <p className={styles.description}>{metric.description}</p>


### PR DESCRIPTION
This pull request addresses an issue where the impact metric counts were rendering '0' during SSR or when JS hadn't hydrated yet. Now, it defaults to showing the final formatted value during SSR, and transitions to counting up once the component is mounted and scrolled into view.

* **ImpactMatrix.tsx:** Swapped '0' for the target metric value when not in browser/in view.

---
*PR created automatically by Jules for task [18310747255634328505](https://jules.google.com/task/18310747255634328505) started by @juanfe2793*