### PR TITLE
feat(blog): implement MDX post template, author footer, and series navigation

### DIFF
--- a/blog/_template.mdx
+++ b/blog/_template.mdx
@@ -1,0 +1,54 @@
+---
+title: "Your Blog Post Title"
+slug: your-blog-post-slug
+date: 2026-04-25T10:00:00
+authors: [juanfe]
+tags: [tag1, tag2]
+# Optional series frontmatter for custom series navigation component:
+# series: "Platform Engineering"
+# prev_series_slug: "/blog/previous-post-slug"
+# prev_series_title: "Previous Post Title"
+# next_series_slug: "/blog/next-post-slug"
+# next_series_title: "Next Post Title"
+---
+
+A short, engaging introduction to your blog post. This part appears in the blog post list view.
+
+{/* truncate */}
+
+The rest of your content goes here.
+
+## Reusable Components Examples
+
+### Callout Boxes (Admonitions)
+
+:::tip Pro Tip
+This is a tip admonition. You can also use `:::note`, `:::info`, `:::warning`, and `:::danger`.
+:::
+
+### Code Tabs
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+  <TabItem value="apple" label="Apple" default>
+    This is an apple 🍎
+  </TabItem>
+  <TabItem value="orange" label="Orange">
+    This is an orange 🍊
+  </TabItem>
+  <TabItem value="banana" label="Banana">
+    This is a banana 🍌
+  </TabItem>
+</Tabs>
+
+### Architecture Diagrams (Mermaid)
+
+```mermaid
+graph TD;
+    A-->B;
+    A-->C;
+    B-->D;
+    C-->D;
+```

--- a/blog/tags.yml
+++ b/blog/tags.yml
@@ -7,3 +7,17 @@ career:
   label: Career
   permalink: /career
   description: Career development and professional growth
+sre:
+  label: SRE
+  permalink: /sre
+  description: Site Reliability Engineering topics
+
+platform-engineering:
+  label: Platform Engineering
+  permalink: /platform-engineering
+  description: Platform Engineering topics
+
+leadership:
+  label: Leadership
+  permalink: /leadership
+  description: Engineering leadership topics

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -96,7 +96,7 @@ const config: Config = {
         blog: {
           path: 'blog',
           showReadingTime: true,
-          truncateMarker: /<!--\s*(truncate)\s*-->/,
+          truncateMarker: /(<!--\s*(truncate)\s*-->|{\/\*\s*(truncate)\s*\*\/})/,
           feedOptions: {
             type: ['rss', 'atom'],
             xslt: true,

--- a/src/components/AuthorFooter/index.tsx
+++ b/src/components/AuthorFooter/index.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import Link from '@docusaurus/Link';
+import styles from './styles.module.css';
+
+interface Author {
+  name?: string;
+  title?: string;
+  url?: string;
+  imageURL?: string;
+}
+
+interface AuthorFooterProps {
+  authors?: Author[];
+}
+
+export default function AuthorFooter({ authors }: AuthorFooterProps) {
+  if (!authors || authors.length === 0) return null;
+
+  return (
+    <div className={styles.authorFooterContainer}>
+      <div className={styles.authorFooterHeader}>About the Author{authors.length > 1 ? 's' : ''}</div>
+      <div className={styles.authorList}>
+        {authors.map((author, index) => (
+          <div key={index} className={styles.authorCard}>
+            {author.imageURL && (
+              <img src={author.imageURL} alt={author.name || 'Author'} className={styles.authorImage} />
+            )}
+            <div className={styles.authorInfo}>
+              {author.url ? (
+                <Link to={author.url} className={styles.authorNameLink}>
+                  <h4 className={styles.authorName}>{author.name || 'Anonymous'}</h4>
+                </Link>
+              ) : (
+                <h4 className={styles.authorName}>{author.name || 'Anonymous'}</h4>
+              )}
+              {author.title && <div className={styles.authorTitle}>{author.title}</div>}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/AuthorFooter/styles.module.css
+++ b/src/components/AuthorFooter/styles.module.css
@@ -1,0 +1,68 @@
+.authorFooterContainer {
+  margin-top: 3rem;
+  padding-top: 2rem;
+  border-top: 1px solid var(--rule);
+}
+
+.authorFooterHeader {
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--ink-soft);
+  margin-bottom: 1.5rem;
+}
+
+.authorList {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.authorCard {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  padding: 1.25rem;
+  background: var(--paper-deep);
+  border: 1px solid var(--rule);
+  border-radius: 8px;
+}
+
+.authorImage {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 2px solid var(--paper);
+  box-shadow: 0 0 0 1px var(--rule);
+}
+
+.authorInfo {
+  display: flex;
+  flex-direction: column;
+}
+
+.authorName {
+  margin: 0 0 0.25rem 0;
+  font-size: 1.15rem;
+  font-weight: 600;
+  color: var(--ink);
+  line-height: 1.2;
+}
+
+.authorNameLink {
+  color: var(--ink);
+  text-decoration: none;
+  transition: color 150ms ease-out;
+}
+
+.authorNameLink:hover {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.authorTitle {
+  font-size: 0.9rem;
+  color: var(--ink-soft);
+}

--- a/src/components/SeriesNavigation/index.tsx
+++ b/src/components/SeriesNavigation/index.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import Link from '@docusaurus/Link';
+import styles from './styles.module.css';
+
+interface SeriesNavigationProps {
+  seriesName?: string;
+  prevLink?: string;
+  prevTitle?: string;
+  nextLink?: string;
+  nextTitle?: string;
+}
+
+export default function SeriesNavigation({ seriesName, prevLink, prevTitle, nextLink, nextTitle }: SeriesNavigationProps) {
+  if (!seriesName) return null;
+
+  return (
+    <div className={styles.seriesNavContainer}>
+      <h4 className={styles.seriesNavHeader}>Series: {seriesName}</h4>
+      <div className={styles.seriesNavLinks}>
+        {prevLink ? (
+          <Link to={prevLink} className={styles.seriesNavLink}>
+            <span className={styles.seriesNavLabel}>&larr; Previous</span>
+            <span className={styles.seriesNavTitle}>{prevTitle || 'Previous Post'}</span>
+          </Link>
+        ) : (
+          <div className={styles.seriesNavLinkPlaceholder} />
+        )}
+
+        {nextLink ? (
+          <Link to={nextLink} className={styles.seriesNavLink} style={{textAlign: 'right'}}>
+            <span className={styles.seriesNavLabel}>Next &rarr;</span>
+            <span className={styles.seriesNavTitle}>{nextTitle || 'Next Post'}</span>
+          </Link>
+        ) : (
+          <div className={styles.seriesNavLinkPlaceholder} />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/SeriesNavigation/styles.module.css
+++ b/src/components/SeriesNavigation/styles.module.css
@@ -1,0 +1,71 @@
+.seriesNavContainer {
+  margin-top: 2.5rem;
+  margin-bottom: 2.5rem;
+  padding: 1.5rem;
+  border: 1px solid var(--rule);
+  border-radius: 8px;
+  background-color: var(--paper-deep);
+}
+
+.seriesNavHeader {
+  margin-top: 0;
+  margin-bottom: 1.25rem;
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--ink-soft);
+  text-align: center;
+}
+
+.seriesNavLinks {
+  display: flex;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+
+.seriesNavLink {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  padding: 1.25rem;
+  border: 1px solid var(--rule);
+  border-radius: 6px;
+  text-decoration: none;
+  background-color: var(--paper);
+  transition: border-color 150ms ease-out, background 150ms ease-out;
+}
+
+.seriesNavLink:hover {
+  border-color: var(--accent);
+  text-decoration: none;
+}
+
+.seriesNavLinkPlaceholder {
+  flex: 1;
+}
+
+.seriesNavLabel {
+  font-size: 0.75rem;
+  color: var(--ink-soft);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 0.5rem;
+}
+
+.seriesNavTitle {
+  font-size: 1rem;
+  color: var(--ink);
+  font-weight: 600;
+  line-height: 1.4;
+}
+
+.seriesNavLink:hover .seriesNavTitle {
+  color: var(--accent);
+}
+
+@media screen and (max-width: 600px) {
+  .seriesNavLinks {
+    flex-direction: column;
+  }
+}

--- a/src/theme/BlogPostItem/Footer/ReadMoreLink/index.tsx
+++ b/src/theme/BlogPostItem/Footer/ReadMoreLink/index.tsx
@@ -1,0 +1,37 @@
+import React, {type ReactNode} from 'react';
+import Translate, {translate} from '@docusaurus/Translate';
+import Link from '@docusaurus/Link';
+import type {Props} from '@theme/BlogPostItem/Footer/ReadMoreLink';
+
+function ReadMoreLabel() {
+  return (
+    <b>
+      <Translate
+        id="theme.blog.post.readMore"
+        description="The label used in blog post item excerpts to link to full blog posts">
+        Read more
+      </Translate>
+    </b>
+  );
+}
+
+export default function BlogPostItemFooterReadMoreLink(
+  props: Props,
+): ReactNode {
+  const {blogPostTitle, ...linkProps} = props;
+  return (
+    <Link
+      aria-label={translate(
+        {
+          message: 'Read more about {title}',
+          id: 'theme.blog.post.readMoreLabel',
+          description:
+            'The ARIA label for the link to full blog posts from excerpts',
+        },
+        {title: blogPostTitle},
+      )}
+      {...linkProps}>
+      <ReadMoreLabel />
+    </Link>
+  );
+}

--- a/src/theme/BlogPostItem/Footer/index.tsx
+++ b/src/theme/BlogPostItem/Footer/index.tsx
@@ -1,0 +1,105 @@
+import React, {type ReactNode} from 'react';
+import clsx from 'clsx';
+import {useBlogPost} from '@docusaurus/plugin-content-blog/client';
+import {ThemeClassNames} from '@docusaurus/theme-common';
+import EditMetaRow from '@theme/EditMetaRow';
+import TagsListInline from '@theme/TagsListInline';
+import ReadMoreLink from '@theme/BlogPostItem/Footer/ReadMoreLink';
+import SeriesNavigation from '@site/src/components/SeriesNavigation';
+import AuthorFooter from '@site/src/components/AuthorFooter';
+
+export default function BlogPostItemFooter(): ReactNode {
+  const {metadata, isBlogPostPage} = useBlogPost();
+  const {
+    tags,
+    title,
+    editUrl,
+    hasTruncateMarker,
+    lastUpdatedBy,
+    lastUpdatedAt,
+    authors,
+    frontMatter,
+  } = metadata;
+
+  // A post is truncated if it's in the "list view" and it has a truncate marker
+  const truncatedPost = !isBlogPostPage && hasTruncateMarker;
+
+  const tagsExists = tags.length > 0;
+
+  // BlogPost footer - details view
+  if (isBlogPostPage) {
+    const canDisplayEditMetaRow = !!(editUrl || lastUpdatedAt || lastUpdatedBy);
+
+    const seriesName = frontMatter.series as string | undefined;
+    const prevLink = frontMatter.prev_series_slug as string | undefined;
+    const prevTitle = frontMatter.prev_series_title as string | undefined;
+    const nextLink = frontMatter.next_series_slug as string | undefined;
+    const nextTitle = frontMatter.next_series_title as string | undefined;
+
+    return (
+      <footer className="docusaurus-mt-lg">
+        {seriesName && (
+          <SeriesNavigation
+            seriesName={seriesName}
+            prevLink={prevLink}
+            prevTitle={prevTitle}
+            nextLink={nextLink}
+            nextTitle={nextTitle}
+          />
+        )}
+
+        {tagsExists && (
+          <div
+            className={clsx(
+              'row',
+              'margin-top--sm',
+              ThemeClassNames.blog.blogFooterEditMetaRow,
+            )}>
+            <div className="col">
+              <TagsListInline tags={tags} />
+            </div>
+          </div>
+        )}
+
+        <AuthorFooter authors={authors} />
+
+        {canDisplayEditMetaRow && (
+          <EditMetaRow
+            className={clsx(
+              'margin-top--sm',
+              ThemeClassNames.blog.blogFooterEditMetaRow,
+            )}
+            editUrl={editUrl}
+            lastUpdatedAt={lastUpdatedAt}
+            lastUpdatedBy={lastUpdatedBy}
+          />
+        )}
+      </footer>
+    );
+  }
+
+  // BlogPost footer - list view
+  const renderFooter = tagsExists || truncatedPost;
+
+  if (!renderFooter) {
+    return null;
+  }
+
+  return (
+    <footer className="row docusaurus-mt-lg">
+      {tagsExists && (
+        <div className={clsx('col', {'col--9': truncatedPost})}>
+          <TagsListInline tags={tags} />
+        </div>
+      )}
+      {truncatedPost && (
+        <div
+          className={clsx('col text--right', {
+            'col--3': tagsExists,
+          })}>
+          <ReadMoreLink blogPostTitle={title} to={metadata.permalink} />
+        </div>
+      )}
+    </footer>
+  );
+}


### PR DESCRIPTION
Fixes #81

Design and implement a reusable MDX blog post template with standard frontmatter, reusable components, author footer, series navigation, and auto-generated table of contents.

**Changes:**
- Ejected `@docusaurus/theme-classic BlogPostItem/Footer` to conditionally render custom Series and Author components at the bottom of single blog posts.
- Created `AuthorFooter` to display Docusaurus `authors.yml` data.
- Created `SeriesNavigation` component powered by optional custom frontmatter fields (`series`, `prev_series_slug`, `prev_series_title`, `next_series_slug`, `next_series_title`).
- Provided a ready-to-copy `blog/_template.mdx` featuring all standard fields and examples of native Docusaurus reusable components like Callout Boxes, Tabs, and Architecture Diagrams.
- Updated `docusaurus.config.ts`'s `truncateMarker` to match MDX standard `{/* truncate */}` comments alongside legacy HTML comments to ensure error-free builds.

---
*PR created automatically by Jules for task [2842485519419864846](https://jules.google.com/task/2842485519419864846) started by @juanfe2793*