### PR TITLE
Fix MDX parsing error in cv.mdx blocking build

### DIFF
--- a/docs/portfolio/cv.mdx
+++ b/docs/portfolio/cv.mdx
@@ -111,7 +111,7 @@ Expert in scaling cloud-native infrastructure, high-throughput API gateways, and
           <ul style={{ margin: "0.25rem 0 0.75rem 0", paddingLeft: "1.25rem" }}>
             <li>
               Led NLB configuration hardening after production incidents;
-              improved TwilioKubernetesPlatform -> ClassicTwilioPlatform success rate 96.33% → 99.90%.
+              improved TwilioKubernetesPlatform &rarr; ClassicTwilioPlatform success rate 96.33% → 99.90%.
             </li>
             <li>
               Implemented Kong observability via OpenTelemetry sidecar exporting


### PR DESCRIPTION
Fixes an MDX/JSX parsing error in the Curriculum Vitae page where an unescaped `->` sequence within JSX was causing the Docusaurus production build to fail with `Could not parse expression with acorn`. Replaced it with the `&rarr;` HTML entity to resolve the compilation issue and unblock GitHub Pages publication.

---
*PR created automatically by Jules for task [4445278966047503299](https://jules.google.com/task/4445278966047503299) started by @juanfe2793*