### PR TITLE
Configure RSS feeds and Open Graph metadata for blog

### DIFF
--- a/blog/2026-01-17-welcome.md
+++ b/blog/2026-01-17-welcome.md
@@ -4,6 +4,7 @@ slug: dispatches-from-the-platform-layer
 date: 2026-01-17
 authors: [juanfe]
 tags: [sre, platform-engineering, leadership]
+image: https://juanfe2793.github.io/Portfolio/img/docusaurus-social-card.jpg
 ---
 
 The SRE title is a misnomer. We don't *engineer reliability* — reliability is the residual of every other decision the organization makes. What we actually do is hold the line when entropy wins.

--- a/blog/_template.mdx
+++ b/blog/_template.mdx
@@ -4,6 +4,7 @@ slug: your-blog-post-slug
 date: 2026-04-25T10:00:00
 authors: [juanfe]
 tags: [tag1, tag2]
+image: https://juanfe2793.github.io/Portfolio/img/docusaurus-social-card.jpg # Default OG image template (1200x630)
 # Optional series frontmatter for custom series navigation component:
 # series: "Platform Engineering"
 # prev_series_slug: "/blog/previous-post-slug"

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -100,6 +100,9 @@ const config: Config = {
           feedOptions: {
             type: ['rss', 'atom'],
             xslt: true,
+            description: 'Dispatches from the Platform Layer - Juan Felipe Gomez Blog',
+            copyright: `Copyright © ${new Date().getFullYear()} Juan Felipe Gómez Manzanares.`,
+            language: 'en',
           },
           editUrl: 'https://github.com/juanfe2793/Portfolio/tree/main/',
           onInlineTags: 'warn',


### PR DESCRIPTION
Configures the blog RSS feeds to include proper descriptions, language definitions, and copyright information. Also updates the blog post template and the existing post to include a default Open Graph image for social sharing, as part of the Epic 2 Infrastructure Setup.

---
*PR created automatically by Jules for task [2840575097118537101](https://jules.google.com/task/2840575097118537101) started by @juanfe2793*