### PR TITLE
Improve home page UI/UX: fix broken CTAs, clipped metrics, and hidden…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ yarn-error.log*
 .DS_Store
 tmp*
 .worktrees/
+
+# Local logs
+serve.log
+*.log

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,11 +68,11 @@ The theme is called **"Obsidian Command Center"** — dark-first, high-contrast.
 
 | Token | Light | Dark |
 |---|---|---|
-| `--paper` | `#FAF7F0` | `#000000` (OLED) |
+| `--paper` | `#F9FAFB` | `#000000` (OLED) |
 | `--ink` | `#141414` | `#FFFFFF` |
-| `--ink-soft` | `#4A4A48` | `#A1A1AA` |
-| `--accent` | `#B43A0B` (burnt orange) | `#00D1FF` (electric blue) |
-| `--accent-deep` | `#7C2D12` | `#00A3C7` |
+| `--ink-soft` | `#4A4A58` | `#A1A1AA` |
+| `--accent` | `#4338CA` (indigo) | `#60A5FA` (soft sky blue) |
+| `--accent-deep` | `#3730A3` | `#3B82F6` |
 
 Default color mode is **dark**. Always use these tokens rather than hard-coded colors. Infima variables (`--ifm-color-primary`, etc.) are mapped to these tokens — do not set Infima variables directly.
 

--- a/blog/authors.yml
+++ b/blog/authors.yml
@@ -2,7 +2,7 @@ juanfe:
   name: Juan Felipe Gomez Manzanares
   title: Staff Software Engineer
   url: https://linkedin.com/in/juangomez27
-  image_url: https://github.com/juanfe2793.png
+  image_url: /img/avatar.jpg
   page: true
   socials:
     linkedin: juangomez27

--- a/serve.log
+++ b/serve.log
@@ -1,5 +1,0 @@
-
-> portfolio@0.0.0 serve
-> docusaurus serve
-
-[SUCCESS] Serving "build" directory at: http://localhost:3000/Portfolio/

--- a/src/components/HomepageFeatures/index.tsx
+++ b/src/components/HomepageFeatures/index.tsx
@@ -1,5 +1,5 @@
 import type {ReactNode} from 'react';
-import Heading from '@theme/Heading';
+import clsx from 'clsx';
 import styles from './styles.module.css';
 
 type ExpertiseItem = {
@@ -61,6 +61,3 @@ export default function HomepageFeatures(): ReactNode {
     </section>
   );
 }
-
-// Note: clsx import needed if using it, or just use string template
-import clsx from 'clsx';

--- a/src/components/ImpactMatrix.module.css
+++ b/src/components/ImpactMatrix.module.css
@@ -5,20 +5,27 @@
 
 .bentoGrid {
   display: grid;
-  /* Desktop: 5 columns */
-  grid-template-columns: repeat(5, 1fr);
-  gap: 1.5rem;
+  /* Desktop: 5 columns — minmax(0, 1fr) lets cards shrink instead of clipping */
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 1rem;
 }
 
-/* Tablet: 2 top, 3 bottom (or 3 top, 2 bottom) */
-@media (max-width: 1024px) {
+/* Tablet: 3 columns */
+@media (max-width: 1100px) {
   .bentoGrid {
-    grid-template-columns: repeat(3, 1fr);
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+/* Small tablet: 2 columns */
+@media (max-width: 768px) {
+  .bentoGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
 /* Mobile: 1 column */
-@media (max-width: 768px) {
+@media (max-width: 480px) {
   .bentoGrid {
     grid-template-columns: 1fr;
   }
@@ -30,11 +37,12 @@
   background: rgba(255, 255, 255, 0.03);
   border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: 12px;
-  padding: 2rem;
+  padding: 1.5rem;
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
-  transition: border-color 0.3s ease;
+  min-width: 0;
+  transition: border-color 0.3s ease, transform 0.3s ease, box-shadow 0.3s ease;
 }
 
 [data-theme='light'] .glassPanel {
@@ -56,6 +64,14 @@
   border-color: var(--accent);
   background: var(--accent-soft);
   text-decoration: none !important;
+  transform: translateY(-3px);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.25);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .glassPanelLink:hover {
+    transform: none;
+  }
 }
 
 .glassPanelLink:hover .value {
@@ -71,11 +87,13 @@
 }
 
 .value {
-  font-size: clamp(2.5rem, 5vw, 4rem);
+  /* Sized so all five cards fit without clipping at desktop widths */
+  font-size: clamp(1.75rem, 2.4vw, 2.5rem);
   font-weight: 700;
   color: var(--accent);
   margin: 0.5rem 0;
   white-space: nowrap;
+  font-variant-numeric: tabular-nums;
 }
 
 .description {

--- a/src/components/ImpactMatrix.tsx
+++ b/src/components/ImpactMatrix.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Link from '@docusaurus/Link';
+import CountUp from 'react-countup';
 import styles from './ImpactMatrix.module.css';
 
 type MetricItem = {
@@ -52,6 +53,9 @@ const metrics: MetricItem[] = [
 ];
 
 export default function ImpactMatrix() {
+  const prefersReducedMotion =
+    typeof window !== 'undefined' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches;
   return (
     <div className={styles.matrixContainer}>
       <div className={styles.bentoGrid}>
@@ -63,7 +67,20 @@ export default function ImpactMatrix() {
             <>
               <span className={styles.label}>{metric.label}</span>
               <div className={styles.value}>
-                {metric.prefix || ''}{value}{metric.suffix || ''}
+                <CountUp
+                  start={0}
+                  end={metric.value}
+                  decimals={metric.decimals || 0}
+                  duration={prefersReducedMotion ? 0 : 1.8}
+                  prefix={metric.prefix || ''}
+                  suffix={metric.suffix || ''}
+                  enableScrollSpy
+                  scrollSpyOnce
+                >
+                  {({ countUpRef }) => (
+                    <span ref={countUpRef}>{metric.prefix || ''}{value}{metric.suffix || ''}</span>
+                  )}
+                </CountUp>
               </div>
               <p className={styles.description}>{metric.description}</p>
             </>

--- a/src/components/ProjectCard/styles.module.css
+++ b/src/components/ProjectCard/styles.module.css
@@ -2,14 +2,23 @@
   display: flex;
   flex-direction: column;
   border: 1px solid var(--rule);
+  border-radius: 8px;
   overflow: hidden;
-  transition: border-color 0.2s ease;
+  transition: border-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
   height: 100%;
   background: var(--paper-deep);
 }
 
 .card:hover {
   border-color: var(--accent);
+  transform: translateY(-4px);
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.25);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .card:hover {
+    transform: none;
+  }
 }
 
 /* System diagram strip */

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -72,10 +72,27 @@
 }
 
 /* Base Element Styling */
+html {
+  scroll-behavior: smooth;
+  /* Keep anchored headings clear of the sticky navbar */
+  scroll-padding-top: calc(var(--ifm-navbar-height, 60px) + 1rem);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+}
+
 body {
   color: var(--ink);
   background-color: var(--paper);
   line-height: 1.6;
+}
+
+::selection {
+  background: var(--accent);
+  color: var(--paper);
 }
 
 h1, h2, h3 {
@@ -83,6 +100,16 @@ h1, h2, h3 {
   letter-spacing: -0.02em;
   color: var(--ink);
   font-weight: 600;
+  text-wrap: balance;
+}
+
+/* Translucent, blurred sticky navbar */
+.navbar {
+  background: color-mix(in srgb, var(--paper) 82%, transparent);
+  backdrop-filter: blur(12px) saturate(1.4);
+  -webkit-backdrop-filter: blur(12px) saturate(1.4);
+  border-bottom: 1px solid var(--rule);
+  box-shadow: none;
 }
 
 h4, h5, h6 {

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -43,74 +43,144 @@
   letter-spacing: 0.1em;
 }
 
-.heroName {
-  font-size: clamp(3rem, 8vw, 5rem);
-  line-height: 0.9;
-  margin: 0;
-  letter-spacing: -0.02em;
+.heroStatus {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  align-self: flex-start;
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+  border: 1px solid var(--rule);
+  border-radius: 999px;
+  padding: 0.4rem 0.9rem;
+  background: var(--accent-soft);
 }
 
-.heroSubtitle {
-  font-family: var(--ifm-font-family-monospace);
-  font-size: 1.1rem;
-  color: var(--ink-soft);
+.statusDot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #34D399;
+  box-shadow: 0 0 0 0 rgba(52, 211, 153, 0.55);
+  animation: statusPulse 2.4s ease-out infinite;
+  flex-shrink: 0;
+}
+
+@keyframes statusPulse {
+  0% { box-shadow: 0 0 0 0 rgba(52, 211, 153, 0.55); }
+  70% { box-shadow: 0 0 0 7px rgba(52, 211, 153, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(52, 211, 153, 0); }
+}
+
+.heroName {
+  font-size: clamp(2.5rem, 5.5vw, 4rem);
+  line-height: 1.05;
+  margin: 0;
+  letter-spacing: -0.02em;
+  text-wrap: balance;
+}
+
+.heroAccent {
+  background: linear-gradient(90deg, var(--accent), var(--accent-deep));
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  color: var(--accent); /* fallback for browsers without background-clip: text */
 }
 
 .heroTagline {
-  font-family: var(--ifm-heading-font-family);
-  font-style: italic;
-  font-size: 1.5rem;
-  max-width: 500px;
+  font-size: 1.2rem;
+  line-height: 1.6;
+  color: var(--ink-soft);
+  max-width: 54ch;
   margin: 0;
+}
+
+.heroTagline strong {
+  color: var(--ink);
 }
 
 .heroActions {
   display: flex;
   align-items: center;
-  gap: 2rem;
+  flex-wrap: wrap;
+  gap: 1rem;
   margin-top: 1.5rem;
 }
 
-
-.ctaSecondary {
-  font-size: 0.875rem;
-}
-
-.heroCtaSecondary {
+.heroCta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  min-height: 48px;
+  padding: 0 1.75rem;
   font-family: var(--ifm-font-family-monospace);
-  font-size: 0.9rem;
+  font-size: 0.85rem;
   font-weight: 600;
-  color: var(--ink);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--paper);
+  background: var(--accent);
+  border: 1px solid var(--accent);
+  border-radius: 6px;
   text-decoration: none;
-  letter-spacing: 0.05em;
-  border-bottom: 1px solid var(--accent);
-  padding-bottom: 2px;
-  transition: color 0.2s ease;
+  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .heroCta:hover {
-  color: var(--accent);
+  color: var(--paper);
+  background: var(--accent-deep);
+  border-color: var(--accent-deep);
+  transform: translateY(-2px);
+  box-shadow: 0 8px 24px var(--accent-soft);
   text-decoration: none;
 }
 
-.ctaSecondary {
-  font-size: 0.875rem;
+.heroCtaArrow {
+  display: inline-block;
+  transition: transform 0.2s ease;
+}
+
+.heroCta:hover .heroCtaArrow {
+  transform: translateX(4px);
 }
 
 .heroCtaSecondary {
+  display: inline-flex;
+  align-items: center;
+  min-height: 48px;
+  padding: 0 1.75rem;
   font-family: var(--ifm-font-family-monospace);
-  color: var(--ink-soft);
-  text-decoration: none;
+  font-size: 0.85rem;
   font-weight: 600;
-  border-bottom: 1px solid var(--rule);
-  padding-bottom: 2px;
-  transition: color 0.2s ease, border-color 0.2s ease;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--ink);
+  border: 1px solid var(--rule);
+  border-radius: 6px;
+  text-decoration: none;
+  transition: color 0.2s ease, border-color 0.2s ease, background 0.2s ease, transform 0.2s ease;
 }
 
 .heroCtaSecondary:hover {
-  color: var(--ink);
-  border-bottom-color: var(--accent);
+  color: var(--accent);
+  border-color: var(--accent);
+  background: var(--accent-soft);
+  transform: translateY(-2px);
   text-decoration: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .statusDot {
+    animation: none;
+  }
+  .heroCta:hover,
+  .heroCtaSecondary:hover {
+    transform: none;
+  }
 }
 
 .heroSocial {
@@ -321,13 +391,15 @@
 
 .principleCard {
   border: 1px solid var(--rule);
+  border-radius: 8px;
   padding: 2rem;
   position: relative;
-  transition: border-color 0.2s ease;
+  transition: border-color 0.2s ease, background 0.2s ease;
 }
 
 .principleCard:hover {
   border-color: var(--accent);
+  background: var(--accent-soft);
 }
 
 .principleNumber {
@@ -388,6 +460,11 @@
   .heroActions {
     flex-wrap: wrap;
     gap: 1rem;
+  }
+  .heroCta,
+  .heroCtaSecondary {
+    width: 100%;
+    justify-content: center;
   }
   .aboutContent {
     grid-template-columns: 1fr;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -18,19 +18,24 @@ function HeroSection() {
     <section className={clsx(styles.hero, 'container')}>
       <div className={styles.heroGrid}>
         <div className={styles.heroLeft}>
+          <div className={styles.heroStatus}>
+            <span className={styles.statusDot} aria-hidden="true" />
+            Staff Software & Platform Engineer · Currently @ Twilio
+          </div>
           <Heading as="h1" className={styles.heroName}>
-            Building Platform Infrastructure<br />for Global-Scale, High-Throughput Systems
+            Building platform infrastructure for{' '}
+            <span className={styles.heroAccent}>global-scale, high-throughput</span> systems
           </Heading>
-          <div className={styles.heroSubtitle}>Staff Software & Platform Engineer · Cloud & AI Infrastructure</div>
           <p className={styles.heroTagline}>
-            10+ years experience Engineer, I architect and build platform infrastructure at the intersection of <strong>reliability, security, scalability, AI</strong>.
+            With 10+ years in cloud infrastructure, I architect and build platforms at the
+            intersection of <strong>reliability, security, scalability, and AI</strong>.
           </p>
           <div className={styles.heroActions}>
             <Link className={styles.heroCta} to="/docs/case-studies">
-              [ Explore Case Studies → ]
+              Explore Case Studies <span className={styles.heroCtaArrow} aria-hidden="true">→</span>
             </Link>
             <Link className={styles.heroCtaSecondary} to="/docs/portfolio/cv">
-              [ View CV ]
+              View CV / Resume
             </Link>
           </div>
           <div className={styles.heroSocial}>
@@ -39,7 +44,13 @@ function HeroSection() {
         </div>
         <div className={styles.heroRight}>
           <figure className={styles.avatarFigure}>
-            <img src={avatarSrc} alt="Juan Felipe Gómez Manzanares" />
+            <img
+              src={avatarSrc}
+              alt="Juan Felipe Gómez Manzanares"
+              width={268}
+              height={268}
+              fetchPriority="high"
+            />
             <figcaption>
               <span className={styles.avatarName}>Juan Felipe Gómez Manzanares</span>
               <span className={styles.avatarCaption}>Executive Profile — 2026</span>
@@ -142,8 +153,16 @@ function CtaSection() {
 
 export default function Home(): ReactNode {
   useEffect(() => {
+    // Reveal once and stop observing — toggling on exit re-hides sections
+    // mid-scroll and leaves them invisible for anyone landing past them.
     const observer = new IntersectionObserver(
-      (entries) => entries.forEach((e) => e.target.classList.toggle(styles.visible, e.isIntersecting)),
+      (entries) =>
+        entries.forEach((e) => {
+          if (e.isIntersecting) {
+            e.target.classList.add(styles.visible);
+            observer.unobserve(e.target);
+          }
+        }),
       { threshold: 0.08 }
     );
     document.querySelectorAll(`.${styles.fadeUp}`).forEach((el) => observer.observe(el));


### PR DESCRIPTION
… sections

UX review of the home page surfaced three user-facing bugs plus several polish gaps against current industry standards:

Bug fixes:
- Hero primary CTA had no base style (.heroCta was never defined) and rendered as plain text; both CTAs are now real buttons with clear primary/secondary hierarchy and 48px touch targets
- Impact metrics grid (5 rigid columns, 4rem nowrap values) clipped the fifth card off-screen at common desktop widths; grid now uses minmax(0,1fr) with responsive breakpoints and right-sized values
- Scroll reveal used classList.toggle, which re-hid About/Principles whenever they left the viewport; sections now reveal once and stay
- Removed duplicate conflicting .heroCtaSecondary/.ctaSecondary blocks and moved a bottom-of-file clsx import to the top

Modernization:
- Hero: status badge with pulsing availability dot, balanced headline with gradient accent, fixed tagline grammar, full-width mobile CTAs
- Impact metrics: count-up animation on scroll via react-countup (already a dependency, previously unused)
- Global: translucent blurred sticky navbar, accent ::selection, smooth scrolling with navbar-aware scroll-padding, text-wrap: balance on headings, card hover lift + shadow micro-interactions
- All motion honors prefers-reduced-motion
- Hero avatar: explicit dimensions + fetchpriority to avoid CLS
- Blog author avatar now served locally instead of from github.com

Housekeeping: CLAUDE.md token table synced to the implemented palette; serve.log untracked and gitignored.


Claude-Session: https://claude.ai/code/session_013Rs5vjoSXDKX5NiH1BZxAr